### PR TITLE
Clarification of FPC lifecycle command and enclave endorsement policy

### DIFF
--- a/text/0000-fabric-private-chaincode-1.0.md
+++ b/text/0000-fabric-private-chaincode-1.0.md
@@ -227,7 +227,7 @@ Hence all data received via transaction invocations (e.g., the transaction propo
 Therefore, all participants/organizations trust a TEE (in particular, the FPC Chaincode Enclave), which can provide such an attestation, regardless of at which peer/organization the TEE is hosted.
 Such trust extends also to enclave signatures issued from attested cryptographic keys.
 It is due to such trust that FPC *implicitly* defines an enclave endorsement policy,
-according to which a single enclave signature is sufficient to [validate](#enclave-endorsement-validation) an FPC transaction.
+according to which a single enclave signature (enclave endorsement) is sufficient to [validate](#enclave-endorsement-validation) an FPC transaction successfully.
 
 
 # FPC 1.0 Application Domain

--- a/text/0000-fabric-private-chaincode-1.0.md
+++ b/text/0000-fabric-private-chaincode-1.0.md
@@ -226,8 +226,9 @@ Hence all data received via transaction invocations (e.g., the transaction propo
 - We additionally require that remote attestations provided by a TEE are authentic and prove that only the code referenced in the attestation could have issued it.
 Therefore, all participants/organizations trust a TEE (in particular, the FPC Chaincode Enclave), which can provide such an attestation, regardless of at which peer/organization the TEE is hosted.
 Such trust extends also to enclave signatures issued from attested cryptographic keys.
-It is due to such trust that FPC *implicitly* defines an enclave endorsement policy,
+It is due to such trust that FPC *implicitly* defines an enclave endorsement policy (see also the [FPC Management API](https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/docs/design/fabric-v2%2B/fpc-management.md) document),
 according to which a single enclave signature (enclave endorsement) is sufficient to [validate](#enclave-endorsement-validation) an FPC transaction successfully.
+For clarity, the (FPC) enclave endorsement policy is different than the (Fabric) validation endorsement policy, the latter of which should be [determined](#enclave-endorsement-validation) from the organizational trust relationships in the Fabric network.
 
 
 # FPC 1.0 Application Domain
@@ -395,7 +396,7 @@ The operation is performed by executing the `initEnclave` admin command (see Ste
 
 FPC implements this command as a regular chaincode method, and uses Fabric's `peer chaincode` command to call it.
 Hence, its implementation does not modify, nor requires any modifications, to the Fabric framework.
-Also, conveniently, the command can be triggered through the FPC Client SDK (see [earlier Deployment Section](#deployment)), which is in turn built on the Fabric Client SDK for Go.
+Also, conveniently, the command can be triggered through the FPC Client SDK (see [Deployment](#deployment) section and [FPC Management API](https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/docs/design/fabric-v2%2B/fpc-management.md) document) which is in turn built on the Fabric Client SDK for Go.
 
 A successful initialization and registration will result in a new entry in the enclave registry namespace on the ledger. In particular, each entry contains enclave credentials, which cryptographically bind the enclave to the chaincode as defined in the chaincode definition.
 

--- a/text/0000-fabric-private-chaincode-1.0.md
+++ b/text/0000-fabric-private-chaincode-1.0.md
@@ -181,7 +181,11 @@ The chaincode deployment follows mostly the standard Fabric procedure:
   peer lifecycle chaincode commit --name ${CC_ID} --version ${MRENCLAVE} ...
   ```
 - Lastly, once the chaincode definition for an FPC Chaincode has been approved by the consortium, 
-  a Chaincode Enclave is created via a new `initEnclave` lifecycle management command. 
+  a Chaincode Enclave must be created via an `initEnclave` FPC-lifecycle command.
+  FPC implements such command as a regular chaincode method invoked through the `peer chaincode` (query) command.
+  Hence, supporting it does not require any modification to the Fabric framework.
+  (See the [Enclave Initialization and Registration](#enclave-initialization-and-registration) section for more details.)
+
   <!-- commented out as not really user visible
     This command triggers the creation of an enclave and registers it at the FPC Registry.  
     The registration includes the attestation of the Chaincode Enclave.
@@ -381,7 +385,10 @@ However, any FPC Chaincode invocation will return an error because the FPC Chain
 
 The administrator of the peer hosting the FPC Chaincode Enclave is responsible for the initialization and registration of the enclave.
 The operation is performed by executing the `initEnclave` admin command (see Step 2 above).
-The command can be triggered through the FPC Client SDK (see [earlier Deployment Section](#deployment)).
+
+FPC implements this command as a regular chaincode method, and uses Fabric's `peer chaincode` command to call it.
+Hence, its implementation does not modify, nor requires any modifications, to the Fabric framework.
+Also, conveniently, the command can be triggered through the FPC Client SDK (see [earlier Deployment Section](#deployment)), which is in turn built on the Fabric Client SDK for Go.
 
 A successful initialization and registration will result in a new entry in the enclave registry namespace on the ledger. In particular, each entry contains enclave credentials, which cryptographically bind the enclave to the chaincode as defined in the chaincode definition.
 

--- a/text/0000-fabric-private-chaincode-1.0.md
+++ b/text/0000-fabric-private-chaincode-1.0.md
@@ -226,9 +226,8 @@ Hence all data received via transaction invocations (e.g., the transaction propo
 - We additionally require that remote attestations provided by a TEE are authentic and prove that only the code referenced in the attestation could have issued it.
 Therefore, all participants/organizations trust a TEE (in particular, the FPC Chaincode Enclave), which can provide such an attestation, regardless of at which peer/organization the TEE is hosted.
 Such trust extends also to enclave signatures issued from attested cryptographic keys.
-It is due to such trust that FPC *implicitly* defines an enclave endorsement policy (see also the [FPC Management API](https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/docs/design/fabric-v2%2B/fpc-management.md) document),
-according to which a single enclave signature (enclave endorsement) is sufficient to [validate](#enclave-endorsement-validation) an FPC transaction successfully.
-For clarity, the (FPC) enclave endorsement policy is different than the (Fabric) validation endorsement policy, the latter of which should be [determined](#enclave-endorsement-validation) from the organizational trust relationships in the Fabric network.
+It is due to such trust that FPC *implicitly* defines a policy (see also the [FPC Management API](https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/docs/design/fabric-v2%2B/fpc-management.md#fpc-endorsement-policies) document) that governs the requirements for a successful [enclave endorsement validation](#enclave-endorsement-validation).
+In particular, according to such policy, a single enclave signature (enclave endorsement) is required to validate an FPC transaction.
 
 
 # FPC 1.0 Application Domain

--- a/text/0000-fabric-private-chaincode-1.0.md
+++ b/text/0000-fabric-private-chaincode-1.0.md
@@ -344,7 +344,7 @@ FPC uses a two-step execution process where first the FPC chaincode executes, an
 The Enclave Endorsement Validation component implements the second step of an FPC chaincode invocation.
 It verifies the correctness of a result of a single FPC Chaincode execution and produces the FPC chaincode state updates as a read/writeset of a traditional Fabric transaction.
 In particular, the Validation Logic receives the output of a FPC Chaincode invocation, which is encrypted and signed by the enclave.
-The validation logic verifies the signature (or endorsement) over the enclave execution response and that the response was produced by an enclave registered at the Enclave Registry.
+The validation logic verifies the signature (or enclave endorsement) over the enclave execution response and that the response was produced by an enclave registered at the Enclave Registry.
 FPC defines an implicit enclave endorsement policy -- richer policies will be supported in [future releases](#feature-roadmap) -- by requiring a single enclave endorsement for validation.
 Once the verification succeeds, the Enclave Endorsement Validation component applies any state updates issued by the FPC Chaincode using `get_state` and `put_state` operations.
 As the Validation logic is bundled together with the FPC Chaincode in a single Fabric chaincode package,


### PR DESCRIPTION
This PR provides clarifications on the `initEnclave` FPC lifecycle command and the enclave endorsement policy.